### PR TITLE
Laying groundwork for snappy, deflate and TLS sockets

### DIFF
--- a/nsq/connection.py
+++ b/nsq/connection.py
@@ -4,6 +4,7 @@ from . import response
 from . import util
 from . import json
 from . import __version__
+from .sockets import TLSSocket, SnappySocket, DeflateSocket
 
 import errno
 import socket
@@ -46,7 +47,13 @@ class Connection(object):
         self.max_rdy_count = sys.maxint
 
         # Check for any options we don't support
-        disallowed = ('tls_v1', 'snappy', 'deflate', 'deflate_level')
+        disallowed = []
+        if not SnappySocket:  # pragma: no branch
+            disallowed.append('snappy')
+        if not DeflateSocket:  # pragma: no branch
+            disallowed.extend(['deflate', 'deflate_level'])
+        if not TLSSocket:  # pragma: no branch
+            disallowed.append('tls_v1')
         for key in disallowed:
             assert not self._identify_options.get(key, False), (
                 'Option %s is not supported' % key)

--- a/nsq/sockets/__init__.py
+++ b/nsq/sockets/__init__.py
@@ -1,0 +1,29 @@
+'''Sockets that wrap different connection types'''
+
+# Not all platforms support all types of sockets provided here. For those that
+# are not available, the corresponding socket wrapper is imported as None.
+
+from .. import logger
+
+# Snappy support
+try:
+    from .snappy import SnappySocket
+except ImportError:  # pragma: no cover
+    logger.warn('Snappy compression not supported')
+    SnappySocket = None
+
+
+# Deflate support
+try:
+    from .deflate import DeflateSocket
+except ImportError:  # pragma: no cover
+    logger.warn('Deflate compression not supported')
+    DeflateSocket = None
+
+
+# The TLS socket
+try:
+    from .tls import TLSSocket
+except ImportError:  # pragma: no cover
+    logger.warn('TLS not supported')
+    TLSSocket = None

--- a/nsq/sockets/base.py
+++ b/nsq/sockets/base.py
@@ -1,0 +1,46 @@
+'''Base socket wrapper'''
+
+
+class SocketWrapper(object):
+    '''Wraps a socket in another layer'''
+    # Methods for which we the default should be to simply pass through to the
+    # underlying socket
+    METHODS = (
+        'accept', 'bind', 'close', 'connect', 'fileno', 'getpeername',
+        'getsockname', 'getsockopt', 'setsockopt', 'gettimeout', 'settimeout',
+        'setblocking', 'listen', 'makefile', 'shutdown'
+    )
+
+    @classmethod
+    def wrap_socket(cls, socket, **options):
+        '''Returns a socket-like object that transparently does compression'''
+        return cls(socket, **options)
+
+    def __init__(self, socket):
+        self._socket = socket
+        for method in self.METHODS:
+            # Check to see if this class overrides this method, and if not, then
+            # we should have it simply map through to the underlying socket
+            if not hasattr(self, method):
+                setattr(self, method, getattr(self._socket, method))
+
+    def send(self, data, flags=0):
+        '''Same as socket.send'''
+        raise NotImplementedError()
+
+    def sendall(self, data, flags=0):
+        '''Same as socket.sendall'''
+        count = len(data)
+        while count:
+            sent = self.send(data, flags)
+            # This could probably be a buffer object
+            data = data[sent:]
+            count -= sent
+
+    def recv(self, nbytes, flags=0):
+        '''Same as socket.recv'''
+        raise NotImplementedError()
+
+    def recv_into(self, buff, nbytes, flags=0):
+        '''Same as socket.recv_into'''
+        raise NotImplementedError('Wrapped sockets do not implement recv_into')

--- a/nsq/sockets/deflate.py
+++ b/nsq/sockets/deflate.py
@@ -1,0 +1,3 @@
+'''Wraps a socket in Deflate compression'''
+
+raise ImportError('Deflate not supported')

--- a/nsq/sockets/snappy.py
+++ b/nsq/sockets/snappy.py
@@ -1,0 +1,3 @@
+'''A socket wrapping snappy compression'''
+
+raise ImportError('Snappy not supported')

--- a/nsq/sockets/tls.py
+++ b/nsq/sockets/tls.py
@@ -1,0 +1,3 @@
+'''Wraps a socket in TLS'''
+
+raise ImportError('TLS not supported')

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -10,7 +10,8 @@ from nsq import connection
 from nsq import constants
 from nsq import response
 from nsq import util
-from common import FakeServerTest
+from nsq import sockets
+from common import FakeServerTest, IntegrationTest
 
 
 class TestConnection(FakeServerTest):
@@ -360,25 +361,29 @@ class TestConnection(FakeServerTest):
             conn = connection.Connection('host', 0, long_id='not-your-fqdn')
             self.assertEqual(conn._identify_options['long_id'], 'not-your-fqdn')
 
-    def test_identify_no_tls(self):
+    def test_identify_tls_unsupported(self):
         '''Raises an exception about the lack of TLS support'''
-        self.assertRaises(
-            AssertionError, connection.Connection, 'host', 0, tls_v1=True)
+        with mock.patch('nsq.connection.TLSSocket', None):
+            self.assertRaises(
+                AssertionError, connection.Connection, 'host', 0, tls_v1=True)
 
-    def test_identify_no_snappy(self):
+    def test_identify_snappy_unsupported(self):
         '''Raises an exception about the lack of snappy support'''
-        self.assertRaises(
-            AssertionError, connection.Connection, 'host', 0, snappy=True)
+        with mock.patch('nsq.connection.SnappySocket', None):
+            self.assertRaises(
+                AssertionError, connection.Connection, 'host', 0, snappy=True)
 
-    def test_identify_no_deflate(self):
+    def test_identify_deflate_unsupported(self):
         '''Raises an exception about the lack of deflate support'''
-        self.assertRaises(
-            AssertionError, connection.Connection, 'host', 0, deflate=True)
+        with mock.patch('nsq.connection.DeflateSocket', None):
+            self.assertRaises(
+                AssertionError, connection.Connection, 'host', 0, deflate=True)
 
     def test_identify_no_deflate_level(self):
-        '''Raises an exception about the lack of deflat_level support'''
-        self.assertRaises(AssertionError,
-            connection.Connection, 'host', 0, deflate_level=True)
+        '''Raises an exception about the lack of deflate_level support'''
+        with mock.patch('nsq.connection.DeflateSocket', None):
+            self.assertRaises(AssertionError,
+                connection.Connection, 'host', 0, deflate_level=True)
 
     def test_identify_no_snappy_and_deflate(self):
         '''We should yell early about incompatible snappy and deflate options'''

--- a/test/test_sockets/test_base.py
+++ b/test/test_sockets/test_base.py
@@ -1,0 +1,51 @@
+import mock
+import unittest
+
+from nsq.sockets.base import SocketWrapper
+
+
+class TestSocketWrapper(unittest.TestCase):
+    '''Test the SocketWrapper class'''
+    def setUp(self):
+        self.socket = mock.Mock()
+        self.wrapped = SocketWrapper.wrap_socket(self.socket)
+
+    def test_wrap_socket(self):
+        '''Passes through objects to the constructor'''
+        with mock.patch.object(SocketWrapper, '__init__') as mock_init:
+            mock_init.return_value = None
+            SocketWrapper.wrap_socket(5, hello='foo')
+            mock_init.assert_called_with(5, hello='foo')
+
+    def test_method_pass_through(self):
+        '''Passes through most methods directly to the underlying socket'''
+        self.assertEqual(self.wrapped.accept, self.socket.accept)
+
+    def test_send(self):
+        '''SocketWrapper.send saises NotImplementedError'''
+        self.assertRaises(NotImplementedError, self.wrapped.send, 'foo')
+
+    def test_sendall(self):
+        '''Repeatedly calls send until everything has been sent'''
+        with mock.patch.object(self.wrapped, 'send') as mock_send:
+            # Only sends one byte at a time
+            mock_send.return_value = 1
+            self.wrapped.sendall('hello')
+            self.assertEqual(mock_send.call_count, 5)
+
+    def test_recv(self):
+        '''SocketWrapper.recv saises NotImplementedError'''
+        self.assertRaises(NotImplementedError, self.wrapped.recv, 5)
+
+    def test_recv_into(self):
+        '''SocketWrapper.recv_into saises NotImplementedError'''
+        self.assertRaises(NotImplementedError, self.wrapped.recv_into, 'foo', 5)
+
+    def test_inheritance_overrides(self):
+        '''Classes that inherit can override things like accept'''
+        class Foo(SocketWrapper):
+            def close(self):
+                pass
+
+        wrapped = Foo.wrap_socket(self.socket)
+        self.assertNotEqual(wrapped.close, self.socket.close)


### PR DESCRIPTION
Though not supported, I wanted to articulate the plan for having `TLS`, `snappy` and `deflate` support.
