### PR TITLE
Check for Reconnection

### DIFF
--- a/nsq/checker.py
+++ b/nsq/checker.py
@@ -1,0 +1,52 @@
+'''A class that checks connections'''
+
+import time
+import threading
+
+
+class StoppableThread(threading.Thread):
+    '''A thread that may be stopped'''
+    def __init__(self):
+        threading.Thread.__init__(self)
+        self._event = threading.Event()
+
+    def wait(self, timeout):
+        '''Wait for the provided time to elapse'''
+        return self._event.wait(timeout)
+
+    def stop(self):
+        '''Set the stop condition'''
+        self._event.set()
+
+
+class PeriodicThread(StoppableThread):
+    '''A thread that periodically invokes a callback every interval seconds'''
+    def __init__(self, interval, callback, *args, **kwargs):
+        StoppableThread.__init__(self)
+        self._interval = interval
+        self._callback = callback
+        self._args = args
+        self._kwargs = kwargs
+        self._last_checked = None
+
+    def delay(self):
+        '''How long to wait before the next check'''
+        if self._last_checked:
+            return self._interval - (time.time() - self._last_checked)
+        return self._interval
+
+    def callback(self):
+        '''Run the callback'''
+        self._callback(*self._args, **self._kwargs)
+        self._last_checked = time.time()
+
+    def run(self):
+        '''Run the callback periodically'''
+        while not self.wait(self.delay()):
+            self.callback()
+
+
+class ConnectionChecker(PeriodicThread):
+    '''A thread that checks the connections on an object'''
+    def __init__(self, client, interval=60):
+        PeriodicThread.__init__(self, interval, client.check_connections)

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -63,10 +63,11 @@ class Reader(Client):
         return found
 
     def __iter__(self):
-        while True:
-            for message in self.read():
-                # A reader's only interested in actual messages
-                if isinstance(message, Message):
-                    # We'll probably add a hook in here to track the RDY states
-                    # of our connections
-                    yield message
+        with self.connection_checker():
+            while True:
+                for message in self.read():
+                    # A reader's only interested in actual messages
+                    if isinstance(message, Message):
+                        # We'll probably add a hook in here to track the RDY
+                        # states of our connections
+                        yield message

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -1,0 +1,52 @@
+'''Tests about our connection-checking thread'''
+
+import mock
+import unittest
+import threading
+
+from nsq.checker import PeriodicThread, ConnectionChecker
+
+
+class TestPeriodicThread(unittest.TestCase):
+    '''Can stop a PeriodicThread'''
+    def test_stop(self):
+        '''Stop is effective for stopping a stoppable thread'''
+        def callback(event):
+            '''Trigger an event'''
+            event.set()
+
+        event = threading.Event()
+        thread = PeriodicThread(0.01, callback, event)
+        thread.start()
+        event.wait()
+        thread.stop()
+        thread.join()
+        self.assertFalse(thread.is_alive())
+
+    def test_repeats(self):
+        '''Repeats the same callback several times'''
+        def callback(event, counter):
+            '''Trigger an event after accumulating enough'''
+            counter['count'] += 1
+            if counter['count'] > 10:
+                event.set()
+
+        event = threading.Event()
+        counter = {'count': 0}
+        thread = PeriodicThread(0.01, callback, event, counter)
+        thread.start()
+        event.wait()
+        thread.stop()
+        thread.join()
+        self.assertGreaterEqual(counter['count'], 10)
+
+
+class TestConnectionChecker(unittest.TestCase):
+    '''ConnectionChecker tests'''
+    def test_callback(self):
+        '''Provides the client's connection checking method'''
+        with mock.patch.object(PeriodicThread, '__init__') as mock_init:
+            mock_client = mock.Mock()
+            checker = ConnectionChecker(mock_client, 10)
+            mock_init.assert_called_with(
+                checker, 10, mock_client.check_connections)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -44,7 +44,14 @@ class TestClientNsqd(FakeServerTest):
             with mock.patch.object(
                 self.client, '_identify_options', {'foo': 'bar'}):
                 self.client.connect('foo', 'bar')
-                MockConnection.assert_called_with('foo', 'bar', foo='bar')
+                MockConnection.assert_called_with('foo', 'bar',
+                    reconnection_backoff=None, foo='bar')
+
+    def test_conection_checker(self):
+        '''Spawns and starts a connection checker'''
+        with self.client.connection_checker() as checker:
+            self.assertTrue(checker.is_alive())
+        self.assertFalse(checker.is_alive())
 
 
 class TestClientLookupd(FakeServerTest):


### PR DESCRIPTION
This provides a context manager that spawns (and stops and joins) a thread that periodically checks the connections associated with a client. The gevent implementation uses a coroutine, since it monkey-patches threading.
