### PR TITLE
Corrected producer lookup in nsq clients.

### DIFF
--- a/nsq/client.py
+++ b/nsq/client.py
@@ -52,7 +52,7 @@ class Client(object):
         for lookupd in self._lookupd:
             try:
                 # Find all the current producers on this instance
-                for producer in lookupd.lookup(topic)['data']['producers']:
+                for producer in lookupd.lookup(topic)['producers']:
                     producers.append(
                         (producer['broadcast_address'], producer['tcp_port']))
             except ClientException:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -69,12 +69,10 @@ class TestClientLookupd(FakeServerTest):
         '''Return a new client'''
         with mock.patch('nsq.client.nsqlookupd.Client') as MockClass:
             MockClass.return_value.lookup.return_value = {
-                'data': {
-                    'producers': [{
-                        'broadcast_address': 'localhost',
-                        'tcp_port': self.ports[0]
-                    }]
-                }
+                'producers': [{
+                    'broadcast_address': 'localhost',
+                    'tcp_port': self.ports[0]
+                }]
             }
             return client.Client(topic='foo',
                 lookupd_http_addresses=['http://localhost:1234'])


### PR DESCRIPTION
nsqlookupd "lookup" is wrong in client discover. It is trying to get the 'data' json key already "removed" in wrap_json decorator.

This PR will correct this.

Signed-off-by: David Saradini david.saradini@me.com
