### PR TITLE
Reduce logging around http clients

### DIFF
--- a/nsq/http/__init__.py
+++ b/nsq/http/__init__.py
@@ -12,7 +12,7 @@ def wrap(function, *args, **kwargs):
     '''Wrap a function that returns a request with some exception handling'''
     try:
         req = function(*args, **kwargs)
-        logger.info('Got %s: %s', req.status_code, req.content)
+        logger.debug('Got %s: %s', req.status_code, req.content)
         if req.status_code == 200:
             return req
         else:
@@ -66,11 +66,12 @@ class BaseClient(object):
     def get(self, path, *args, **kwargs):
         '''GET the provided endpoint'''
         url = 'http://%s:%s%s' % (self._host, self._port, path)
-        logger.info('Get %s with %s, %s', url, args, kwargs)
+        logger.debug('GET %s with %s, %s', url, args, kwargs)
         return requests.get(url, *args, **kwargs)
 
     @wrap
     def post(self, path, *args, **kwargs):
         '''POST to the provided endpoint'''
-        return requests.post(
-            'http://%s:%s%s' % (self._host, self._port, path), *args, **kwargs)
+        url = 'http://%s:%s%s' % (self._host, self._port, path)
+        logger.debug('POST %s with %s, %s', url, args, kwargs)
+        return requests.post(url, *args, **kwargs)


### PR DESCRIPTION
I accidentally let some logging trickle into the HTTP clients, so now I'm paring it back a bit. Logging was a performance issue at one point in hot sections (in particular `nsq.connection.Connection.read`), but the HTTP clients aren't performance-critical and the logging isn't in a hot loop, so a small amount of logging is reasonable.
