### PR TITLE
Reader only runs reconnection hook if connection is alive

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -20,7 +20,8 @@ class Reader(Client):
 
     def added(self, conn):
         '''Subscribe connection and manipulate its RDY state'''
-        self.reconnected(conn)
+        if conn.alive():
+            self.reconnected(conn)
 
     def distribute_ready(self):
         '''Distribute the ready state across all of the connections'''

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -37,6 +37,14 @@ class TestReader(HttpClientIntegrationTest):
         self.client.reconnected(connection)
         connection.rdy.assert_called_with(1)
 
+    def test_added_dead(self):
+        '''Does not call reconnected when adding dead connections'''
+        conn = mock.Mock()
+        conn.alive.return_value = False
+        with mock.patch.object(self.client, 'reconnected') as mock_reconnected:
+            self.client.added(conn)
+            self.assertFalse(mock_reconnected.called)
+
     def test_it_checks_max_in_flight(self):
         '''Raises an exception if more connections than in-flight limit'''
         with mock.patch.object(self.client, '_max_in_flight', 0):


### PR DESCRIPTION
While `added` is correctly dispatched when adding a new connection (dead or alive), in the case of `Reader`, the `reconnected` hook should only be dispatched if the added connection is alive.
