### PR TITLE
RDY messages re-sent when a failed connection exists

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -45,7 +45,7 @@ class Reader(Client):
         '''Determine whether or not we need to redistribute the ready state'''
         # Try to pre-empty starvation by comparing current RDY against
         # the last value sent.
-        alive = [c for c in self.connections()]
+        alive = [c for c in self.connections() if c.alive()]
         if any(c.ready <= (c.last_ready_sent * 0.25) for c in alive):
             return True
 


### PR DESCRIPTION
I was poking around and hit this case in testing out where any dead connection (for me it was an unreachable address returned from lookukpd) triggered the logic to re-send RDY because last RDY was 0.
