### PR TITLE
Cleanup pending socket data on close

### DIFF
--- a/nsq/connection.py
+++ b/nsq/connection.py
@@ -129,6 +129,7 @@ class Connection(object):
                 if self._socket:
                     self._socket.close()
                 self._socket = None
+                self._pending = deque([])
                 self._reconnnection_counter.failed()
                 return False
 
@@ -145,6 +146,7 @@ class Connection(object):
                 if self._socket:
                     self._socket.close()
             finally:
+                self._pending = deque([])
                 self._socket = None
 
     def socket(self, blocking=True):


### PR DESCRIPTION
A client failed with data in the pending queue (I had killed nsqd and added this debug line on RDY send)

```
[I 140724 22:21:36 connection:276] [127.0.0.1:4152] RDY 100
2014-07-24 22:21:36,812 [ERROR] client.py@219: Failed to read from <Connection 127.0.0.1:4152 (alive on FD 7)>
Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/nsq/client.py", line 196, in read
    for res in conn.read():
  File "/Library/Python/2.7/site-packages/nsq/connection.py", line 345, in read
    responses = self._read()
  File "/Library/Python/2.7/site-packages/nsq/connection.py", line 310, in _read
    packet = sock.recv(4096)
error: [Errno 54] Connection reset by peer
```

Then on a subsequent Client.read() because connection._pending wasn't cleared out

```
Traceback (most recent call last):
  File "test_nsqpy.py", line 12, in <module>
    for message in reader:
  File "/Library/Python/2.7/site-packages/nsq/reader.py", line 79, in __iter__
    for message in self.read():
  File "/Library/Python/2.7/site-packages/nsq/reader.py", line 67, in read
    found = Client.read(self)
  File "/Library/Python/2.7/site-packages/nsq/client.py", line 185, in read
    connections, writes, connections, self._timeout)
  File "/Library/Python/2.7/site-packages/nsq/connection.py", line 209, in fileno
    return sock.fileno()
AttributeError: 'NoneType' object has no attribute 'fileno'
```
