### PR TITLE
Reduce log severity of socket import messages

### DIFF
--- a/nsq/sockets/__init__.py
+++ b/nsq/sockets/__init__.py
@@ -9,7 +9,7 @@ from .. import logger
 try:
     from .snappy import SnappySocket
 except ImportError:  # pragma: no cover
-    logger.warn('Snappy compression not supported')
+    logger.debug('Snappy compression not supported')
     SnappySocket = None
 
 
@@ -17,7 +17,7 @@ except ImportError:  # pragma: no cover
 try:
     from .deflate import DeflateSocket
 except ImportError:  # pragma: no cover
-    logger.warn('Deflate compression not supported')
+    logger.debug('Deflate compression not supported')
     DeflateSocket = None
 
 


### PR DESCRIPTION
`SnappySocket` and `DeflateSocket` aren't implemented yet. When we try to the import them, a warning is logged, but it isn't actionable.

Happy to add a test if need be.