### PR TITLE
Lower bound instead of pinning (fork source does not specify specific…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name               = 'nsq-py',
         'Operating System :: OS Independent'
     ],
     install_requires=[
-        'requests == 2.2.1',
+        'requests>=2.2.1',
         'decorator==3.4.0',
         'url>=0.1.2'
     ],


### PR DESCRIPTION
… version...)

Pinning this to a specific version results in a conflict with stdlib
https://github.com/lyft/python-lyft-stdlib/blob/master/requirements.txt#L227