### PR TITLE
fix for nsq 1.0 new json response

### DIFF
--- a/nsq/__init__.py
+++ b/nsq/__init__.py
@@ -17,4 +17,4 @@ except ImportError:  # pragma: no cover
     import json
 
 # The current version
-__version__ = '0.1.10'
+__version__ = '0.1.11'

--- a/nsq/http/__init__.py
+++ b/nsq/http/__init__.py
@@ -30,7 +30,11 @@ def json_wrap(function, *args, **kwargs):
     try:
         # Some responses have data = None, but they generally signal a
         # successful API call as well.
-        return json.loads(function(*args, **kwargs).content)['data'] or True
+        response = json.loads(function(*args, **kwargs).content)
+        if 'data' in response:
+            return response['data'] or True
+        else:
+            return response
     except Exception as exc:
         raise ClientException(exc)
 


### PR DESCRIPTION
The latest NSQ 1.0 servers don't put all the JSON inside a "data" element. So if "data" is not there, assume the whole json is the response.

Before: `{"data":{actual answer},...}`. 
It had other field like http exit code, which you can get from the response header.
After: `{actual answer]`

This fix is backward compatible