### PR TITLE
add client_id and hostname according to nsq spec

### DIFF
--- a/nsq/connection.py
+++ b/nsq/connection.py
@@ -43,8 +43,8 @@ class Connection(object):
         self._timeout = timeout if timeout is not None else 1.0
         # The options to use when identifying
         self._identify_options = dict(identify)
-        self._identify_options.setdefault('short_id', socket.gethostname())
-        self._identify_options.setdefault('long_id', socket.getfqdn())
+        self._identify_options.setdefault('hostname', socket.gethostname())
+        self._identify_options.setdefault('client_id', socket.getfqdn().split('.')[0])
         self._identify_options.setdefault('feature_negotiation', True)
         self._identify_options.setdefault('user_agent', self.USER_AGENT)
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -340,8 +340,8 @@ class TestConnection(MockedSocketTest):
         '''Identify provides default options'''
         self.assertEqual(self.connection._identify_options, {
             'feature_negotiation': True,
-            'long_id': socket.getfqdn(),
-            'short_id': socket.gethostname(),
+            'client_id': socket.getfqdn().split('.')[0],
+            'hostname': socket.gethostname(),
             'user_agent': self.connection.USER_AGENT
         })
 


### PR DESCRIPTION
according to https://nsq.io/clients/tcp_protocol_spec.html#identify

`short_id` and `long_id`are no longer used. Repalced them with `hostname` and  `client_id`